### PR TITLE
fix: check Add Reactions permission before creating poll

### DIFF
--- a/cogs/fun.py
+++ b/cogs/fun.py
@@ -218,6 +218,17 @@ class Fun(commands.Cog):
         option9: str = None,
         option10: str = None,
     ):
+        # Check Add Reactions permission before creating the poll
+        bot_member = interaction.guild.me if interaction.guild else None
+        if bot_member and interaction.channel:
+            perms = interaction.channel.permissions_for(bot_member)
+            if not perms.add_reactions:
+                await interaction.response.send_message(
+                    "I need the **Add Reactions** permission in this channel to create polls.",
+                    ephemeral=True,
+                )
+                return
+
         options = [
             opt
             for opt in [option1, option2, option3, option4, option5, option6, option7, option8, option9, option10]


### PR DESCRIPTION
## Bug
#32 — `/poll` sends the poll message first and then tries to add reactions. If the bot lacks **Add Reactions** permission, the poll is posted but the command fails, leaving a broken poll in the channel.

## Fix
Check `add_reactions` permission before sending the poll embed. If missing, return an ephemeral message explaining the issue.

## Testing
- If permission is missing → ephemeral error, no poll posted
- If permission is present → poll created normally with reactions

Happy to address any feedback.

Greetings, saschabuehrle